### PR TITLE
fix: updating wasmer, using new set_tunable function

### DIFF
--- a/tanour/Cargo.toml
+++ b/tanour/Cargo.toml
@@ -8,11 +8,8 @@ edition = "2021"
 [dependencies]
 byteorder = "1.3"
 log = "0.4"
-wasmer = { version = "3.1", default-features = false, features = [
-    "wat",
-    "singlepass",
-] }
-wasmer-middlewares = "3.1"
+wasmer = { version = "4.2.5", default-features = false, features = ["wat", "singlepass"] }
+wasmer-middlewares = "4.2.5"
 thiserror = "1.0"
 hex = "0.4"
 mockall = "0.10"

--- a/tanour/src/wasmer/compile.rs
+++ b/tanour/src/wasmer/compile.rs
@@ -3,8 +3,8 @@ use crate::error::{Error, Result};
 use log::debug;
 use std::sync::Arc;
 use wasmer::{
-    wasmparser::Operator, BaseTunables, CompilerConfig, EngineBuilder, Module, Pages, Singlepass,
-    Store, Target,
+    wasmparser::Operator, BaseTunables, CompilerConfig, EngineBuilder, Module, NativeEngineExt,
+    Pages, Singlepass, Store, Target,
 };
 use wasmer_middlewares::Metering;
 
@@ -26,8 +26,9 @@ pub fn compile(
 
     let base = BaseTunables::for_target(&Target::default());
     let tunables = LimitingTunables::new(base, Pages(memory_limit_page));
-    let store = Store::new_with_tunables(engine, tunables);
-    //let store = Store::default();
+    let store = Store::new(engine);
+    let store_engine = store.engine();
+    store_engine.to_owned().set_tunables(tunables);
 
     let module = Module::new(&store, code).map_err(|original| Error::CompileError {
         msg: format!("{original}"),

--- a/tanour/src/wasmer/limiting_tunables.rs
+++ b/tanour/src/wasmer/limiting_tunables.rs
@@ -125,8 +125,8 @@ impl<T: Tunables> Tunables for LimitingTunables<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wasmer::Singlepass;
     use wasmer::{imports, wat2wasm, BaseTunables, Instance, Memory, Module, Pages, Store, Target};
+    use wasmer::{NativeEngineExt, Singlepass};
 
     #[test]
     fn test_tunables_limit_memory() -> Result<(), Box<dyn std::error::Error>> {
@@ -148,7 +148,9 @@ mod tests {
         let tunables = LimitingTunables::new(base, Pages(24));
 
         // Create a store, that holds the engine and our custom tunables
-        let mut store = Store::new_with_tunables(compiler, tunables);
+        let mut store = Store::new(compiler);
+        let engine = store.engine();
+        engine.to_owned().set_tunables(tunables);
 
         println!("Compiling module...");
         let module = Module::new(&store, wasm_bytes)?;

--- a/tanour/tests/contract_test.rs
+++ b/tanour/tests/contract_test.rs
@@ -1,4 +1,5 @@
 use hex_literal::hex;
+use rand::Rng;
 use tanour::{
     blockchain_api::MockBlockchainAPI,
     contract::{Contract, Params},
@@ -7,7 +8,7 @@ use test_contract::message::{Error, InstantiateMsg, ProcMsg, QueryMsg, QueryRsp}
 
 fn make_test_contract(wat: &[u8], memory_limit_page: u32, metering_limit: u64) -> Contract {
     let code = wat::parse_bytes(wat).unwrap().to_vec();
-    let address = rand::random();
+    let address = rand::thread_rng().gen::<[u8; 21]>();
     let params = Params {
         memory_limit_page,
         metering_limit,


### PR DESCRIPTION
## Description

The current wasmer version doesn't support the `new_with_tubables` function and it's deprecated. This PR will fix that issue by updating the wasmer crate.

## Checklist
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] CHANGELOG is updated.
